### PR TITLE
Enable multi-tab session sync

### DIFF
--- a/writerrank/src/lib/supabase/client.ts
+++ b/writerrank/src/lib/supabase/client.ts
@@ -6,5 +6,10 @@ import { createBrowserClient } from '@supabase/ssr'
 // receive the exact same client instance.
 export const supabase = createBrowserClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  {
+    // Enable multi-tab session syncing and use a custom cookie name
+    auth: { multiTab: true } as any,
+    cookieOptions: { name: 'openwrite-auth-token' },
+  }
 )

--- a/writerrank/src/lib/supabase/server.ts
+++ b/writerrank/src/lib/supabase/server.ts
@@ -34,6 +34,8 @@ export function createClient() {
           }
         },
       },
+      // Use the same cookie name as the browser client
+      cookieOptions: { name: 'openwrite-auth-token' },
     }
   )
 }

--- a/writerrank/src/middleware.ts
+++ b/writerrank/src/middleware.ts
@@ -26,6 +26,8 @@ export async function middleware(request: NextRequest) {
           response.cookies.set({ name, value: '', ...options })
         },
       },
+      // Keep cookie name consistent with client and server helpers
+      cookieOptions: { name: 'openwrite-auth-token' },
     }
   )
 


### PR DESCRIPTION
## Summary
- configure Supabase browser client with `multiTab` support and a custom cookie name
- use the same cookie options in server helpers and middleware

## Testing
- `npm run build` *(fails: ENETUNREACH while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68547423aa5c83329c9a1710b35673e9