### PR TITLE
Fix auth callback middleware handling

### DIFF
--- a/writerrank/src/middleware.ts
+++ b/writerrank/src/middleware.ts
@@ -46,6 +46,6 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      */
-    '/((?!_next/static|_next/image|favicon.ico).*)',
+    '/((?!_next/static|_next/image|favicon.ico|auth/callback).*)',
   ],
 }


### PR DESCRIPTION
## Summary
- skip auth callback route in middleware matcher

## Testing
- `npm ci`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685830d876f88332be2d7c34b1fc2323