### PR TITLE
fix: stabilize save callback to prevent timer reset

### DIFF
--- a/writerrank/src/app/page.tsx
+++ b/writerrank/src/app/page.tsx
@@ -31,34 +31,34 @@ export default function HomePage() {
   const [isLoadingPrompt, setIsLoadingPrompt] = useState(true);
 
   // Save a submission to the DB when the user is authenticated
-  const handleSaveSubmissionToDb = async (
-    finalText: string,
-    isAnonymous: boolean,
-  ) => {
-    if (!user || !currentPrompt) {
-      console.log('Guest submission or missing data. Not saving to DB.');
-      return;
-    }
-    try {
-      const response = await fetch('/api/save-submission', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          promptId: currentPrompt.id,
-          submissionText: finalText,
-          isAnonymous: isAnonymous,
-        }),
-      });
-      if (response.ok) {
-        console.log('Submission saved to database for user:', user.id);
-      } else {
-        const data = await response.json();
-        console.error('Failed to save submission:', data.error);
+  const handleSaveSubmissionToDb = useCallback(
+    async (finalText: string, isAnonymous: boolean) => {
+      if (!user || !currentPrompt) {
+        console.log('Guest submission or missing data. Not saving to DB.');
+        return;
       }
-    } catch (error) {
-      console.error('API call to save submission failed:', error);
-    }
-  };
+      try {
+        const response = await fetch('/api/save-submission', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            promptId: currentPrompt.id,
+            submissionText: finalText,
+            isAnonymous: isAnonymous,
+          }),
+        });
+        if (response.ok) {
+          console.log('Submission saved to database for user:', user.id);
+        } else {
+          const data = await response.json();
+          console.error('Failed to save submission:', data.error);
+        }
+      } catch (error) {
+        console.error('API call to save submission failed:', error);
+      }
+    },
+    [user, currentPrompt],
+  );
 
   // Restore or reset daily challenge state from localStorage
   const setupDailyChallengeState = useCallback(() => {


### PR DESCRIPTION
## Summary
- wrap `handleSaveSubmissionToDb` with `useCallback`
- keep `handleTimeUp` dependent on the new stable handler

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_688ab4ba800c833285fdcfcf9c821bda

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance and reliability of the submission-saving process on the homepage. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->