### PR TITLE
Add custom orange colors and base styles

### DIFF
--- a/writerrank/src/app/globals.css
+++ b/writerrank/src/app/globals.css
@@ -9,6 +9,17 @@ body {
   font-family: sans-serif;
 }
 
+@layer base {
+  :root {
+    --ow-orange-50: theme('colors.ow-orange-50');
+    --ow-orange-500: theme('colors.ow-orange-500');
+  }
+
+  .primary {
+    @apply text-ow-orange-500;
+  }
+}
+
 /* @import "tailwindcss";
 
 :root {

--- a/writerrank/tailwind.config.ts
+++ b/writerrank/tailwind.config.ts
@@ -2,17 +2,17 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
-  content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
-  ],
+  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
     extend: {
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic':
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+      },
+      colors: {
+        'ow-orange-50': '#fff7ed',
+        'ow-orange-500': '#f97316',
       },
     },
   },


### PR DESCRIPTION
## Summary
- extend Tailwind content path and add ow-orange colors
- expose the colors as CSS variables and a `.primary` utility

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_688ba045d2688332bf729597103f903b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced two new theme-based orange color variables for consistent styling.
  * Added a `.primary` text color class for easy application of the new orange color.

* **Chores**
  * Simplified the Tailwind CSS configuration for broader file coverage and maintainability.
  * Extended the theme with custom orange color options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->