### PR TITLE
Remove Inter font usage

### DIFF
--- a/writerrank/src/app/globals.css
+++ b/writerrank/src/app/globals.css
@@ -5,8 +5,7 @@
 
 /* Optional: Add some basic body styling */
 body {
-  @apply bg-gray-100 text-gray-800;
-  font-family: sans-serif;
+  @apply bg-gray-100 text-gray-800 font-sans;
 }
 
 /* @import "tailwindcss";

--- a/writerrank/src/app/layout.tsx
+++ b/writerrank/src/app/layout.tsx
@@ -1,6 +1,5 @@
 // src/app/layout.tsx
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
 
 import {
@@ -12,7 +11,6 @@ import {
   UserButton,
 } from "@clerk/nextjs";
 
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "OpenWrite",
@@ -27,7 +25,7 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="en">
-        <body className={inter.className}>
+        <body>
           {/* Header shows sign-in/up when signed out and user menu when signed in */}
           <header className="flex justify-end items-center p-4 gap-4 h-16">
             <SignedOut>


### PR DESCRIPTION
## Summary
- remove Next.js Inter font from layout
- use Tailwind `font-sans` stack in `globals.css`

## Testing
- `npm run build` *(fails: Failed to patch lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688ba0527dfc8332a8f5a495463d8478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified font styling by consolidating font settings into Tailwind utility classes.
  * Removed the use of the Inter font, reverting to the default sans-serif font styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->