### PR TITLE
Add done page with redirect

### DIFF
--- a/writerrank/src/app/api/save-submission/route.ts
+++ b/writerrank/src/app/api/save-submission/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuth } from '@clerk/nextjs/server';
 import { createClient } from '@/lib/supabase/server';
+import { randomUUID } from 'crypto';
 
 export async function POST(req: NextRequest) {
   // Get the authenticated user ID from Clerk
@@ -32,11 +33,13 @@ export async function POST(req: NextRequest) {
   const supabase = createClient();
 
   // Prepare the submission data, using clerk_id instead of the old user_id
+  const slug = randomUUID();
   const submissionData = {
     clerk_id: userId,
     prompt_id: promptId,
     submission_text: submissionText,
     is_anonymous: isAnonymous,
+    slug,
   };
 
   // Insert the submission into the database
@@ -50,8 +53,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  return NextResponse.json(
-    { message: 'Submission saved successfully!' },
-    { status: 201 },
-  );
+  const redirectUrl = new URL('/done', req.url);
+  redirectUrl.searchParams.set('slug', slug);
+  return NextResponse.redirect(redirectUrl, 303);
 }

--- a/writerrank/src/app/done/page.tsx
+++ b/writerrank/src/app/done/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+const EmailForm = dynamic(() => import('@/components/EmailForm'), { ssr: false });
+const AuthButton = dynamic(() => import('@/components/AuthButton'), { ssr: false });
+
+export default function DonePage() {
+  const searchParams = useSearchParams();
+  const slug = searchParams.get('slug');
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center p-4 bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow-lg max-w-xl w-full text-center">
+        <div className="mb-4">
+          <AuthButton />
+        </div>
+        <h1 className="text-3xl font-bold text-green-600 mb-4">Submission Received</h1>
+        {slug && (
+          <p className="text-gray-600 mb-6">Share or revisit your writing with this link: <span className="font-mono">{slug}</span></p>
+        )}
+        <Suspense fallback={<div>Loading form...</div>}>
+          <EmailForm />
+        </Suspense>
+      </div>
+    </main>
+  );
+}

--- a/writerrank/src/app/page.tsx
+++ b/writerrank/src/app/page.tsx
@@ -4,6 +4,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import PromptDisplay from '../components/PromptDisplay';
 import WritingArea from '../components/WritingArea';
@@ -24,6 +25,7 @@ export default function HomePage() {
   const { user, isLoaded } = useUser();
   // When isLoaded is false, the user info is still loading
   const isAuthLoading = !isLoaded;
+  const router = useRouter();
 
   const [currentPrompt, setCurrentPrompt] = useState<Prompt | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('initial');
@@ -47,7 +49,9 @@ export default function HomePage() {
             isAnonymous: isAnonymous,
           }),
         });
-        if (response.ok) {
+        if (response.redirected) {
+          router.push(response.url);
+        } else if (response.ok) {
           console.log('Submission saved to database for user:', user.id);
         } else {
           const data = await response.json();
@@ -57,7 +61,7 @@ export default function HomePage() {
         console.error('API call to save submission failed:', error);
       }
     },
-    [user, currentPrompt],
+    [user, currentPrompt, router],
   );
 
   // Restore or reset daily challenge state from localStorage


### PR DESCRIPTION
## Summary
- save submissions with a slug and redirect to `/done`
- show confirmation and email form on new `/done` page
- navigate to the redirect URL on the client

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_688ba05c29488332a4aeb964ab2363b2