### PR TITLE
Use dynamic import for AuthButton

### DIFF
--- a/writerrank/src/app/page.tsx
+++ b/writerrank/src/app/page.tsx
@@ -8,7 +8,11 @@ import Link from 'next/link';
 import PromptDisplay from '../components/PromptDisplay';
 import WritingArea from '../components/WritingArea';
 import CompletionView from '../components/CompletionView';
-import AuthButton from '@/components/AuthButton';
+import dynamic from 'next/dynamic';
+
+const AuthButton = dynamic(() => import('@/components/AuthButton'), {
+  ssr: false,
+});
 
 import { useUser } from '@clerk/nextjs';
 


### PR DESCRIPTION
## Summary
- apply `next/dynamic` to load `AuthButton` on the client

## Testing
- `npm install`
- `npx playwright install`
- `npx playwright install-deps`
- `npm test` *(fails: missing swc dependencies and Clerk env keys)*

------
https://chatgpt.com/codex/tasks/task_e_688bb0dd03a08332901f4d23ba736a09