### PR TITLE
Fix PostCSS & Tailwind setup

### DIFF
--- a/writerrank/postcss.config.mjs
+++ b/writerrank/postcss.config.mjs
@@ -1,5 +1,9 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
-};
+import tailwindcss from 'tailwindcss';
+import autoprefixer from 'autoprefixer';
 
-export default config;
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/writerrank/tailwind.config.js
+++ b/writerrank/tailwind.config.js
@@ -1,7 +1,5 @@
-// tailwind.config.ts
-import type { Config } from 'tailwindcss'
-
-const config: Config = {
+/** @type {import('tailwindcss').Config} */
+const config = {
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx,css}'],
   theme: {
     extend: {
@@ -20,4 +18,5 @@ const config: Config = {
   },
   plugins: [],
 }
-export default config
+
+module.exports = config


### PR DESCRIPTION
## Summary
- fix plugin registration in PostCSS config
- switch Tailwind config to JS for Node

## Testing
- `npm test` *(fails: executable doesn't exist for Playwright)*
- `npm run lint` *(interactive prompt)*
- `npx next dev` *(fails to patch lockfile but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_688d14cc187483328f9c5fc3cf6522de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostCSS configuration to explicitly import and configure TailwindCSS and Autoprefixer plugins.
  * Changed Tailwind CSS configuration file from TypeScript to JavaScript syntax and switched to CommonJS export style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->