### PR TITLE
Harmonize completion view colors

### DIFF
--- a/writerrank/src/components/CompletionView.tsx
+++ b/writerrank/src/components/CompletionView.tsx
@@ -10,8 +10,8 @@ interface CompletionViewProps {
 
 const CompletionView: React.FC<CompletionViewProps> = ({ submission, currentPrompt, onWriteAgain }) => {
   return (
-    <div className="w-full max-w-2xl mx-auto my-8 p-6 bg-white rounded-lg shadow-xl text-center">
-      <h2 className="text-3xl font-bold text-green-600 mb-4">Well Done!</h2>
+    <div className="w-full max-w-2xl mx-auto my-8 p-6 bg-white rounded-lg shadow-md text-center">
+      <h2 className="text-3xl font-bold text-[color:var(--ow-orange-500)] mb-4">Well Done!</h2>
       <p className="text-gray-600 mb-6">Here&apos;s what you wrote in 3 minutes:</p>
       <div className="p-4 bg-gray-50 border border-gray-200 rounded-md min-h-[150px] text-left whitespace-pre-wrap mb-8">
         {submission || <span className="text-gray-400">You didn&apos;t write anything this time.</span>}
@@ -26,7 +26,7 @@ const CompletionView: React.FC<CompletionViewProps> = ({ submission, currentProm
 
       <button
         onClick={onWriteAgain}
-        className="px-6 py-2 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        className="px-6 py-2 bg-[color:var(--ow-orange-500)] text-white font-semibold rounded-md hover:bg-[color:var(--ow-orange-500)]/90"
       >
         Ready for Tomorrow&apos;s Prompt
       </button>

--- a/writerrank/src/components/EmailForm.tsx
+++ b/writerrank/src/components/EmailForm.tsx
@@ -126,12 +126,12 @@ export default function EmailForm({ promptText, submissionText }: EmailFormProps
         </button>
       </form>
       {message && (
-        <p className={`mt-4 text-center text-sm ${isError ? 'text-red-600' : 'text-green-700'}`}>
+        <p className={`mt-4 text-center text-sm ${isError ? 'text-red-600' : 'text-[color:var(--ow-neutral-900)]'}`}>
           {message}
         </p>
       )}
       {emailSentMessage && (
-        <p className="mt-2 text-center text-sm text-blue-600">
+        <p className="mt-2 text-center text-sm text-[color:var(--ow-neutral-900)]">
           {emailSentMessage}
         </p>
       )}


### PR DESCRIPTION
## Summary
- update heading and CTA colors in `CompletionView`
- tone down success message colors in `EmailForm`

## Testing
- `npm test` *(fails: missing Playwright browsers)*
- `npm run lint` *(interactive prompt prevents running)*

------
https://chatgpt.com/codex/tasks/task_e_688d15730fb4833281fbaee02256cee5