### PR TITLE
feat: add donation widget component

### DIFF
--- a/writerrank/package-lock.json
+++ b/writerrank/package-lock.json
@@ -12,6 +12,7 @@
         "@clerk/nextjs": "^6.28.0",
         "@react-email/components": "^0.0.41",
         "@react-email/render": "^1.1.2",
+        "@stripe/react-stripe-js": "^3.9.0",
         "@stripe/stripe-js": "^7.8.0",
         "@supabase/ssr": "^0.6.1",
         "@upstash/ratelimit": "^2.0.5",
@@ -2114,6 +2115,20 @@
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.9.0.tgz",
+      "integrity": "sha512-pN1Re7zUc3m61FFQROok685g3zsBQRzCmZDmTzO8iPU6zhLvu2JnC0LrG0FCzSp6kgGa8AQSzq4rpFSgyhkjKg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
     },
     "node_modules/@stripe/stripe-js": {
       "version": "7.8.0",
@@ -6927,7 +6942,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -7304,8 +7318,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-promise-suspense": {
       "version": "0.3.4",

--- a/writerrank/package.json
+++ b/writerrank/package.json
@@ -14,6 +14,7 @@
     "@clerk/nextjs": "^6.28.0",
     "@react-email/components": "^0.0.41",
     "@react-email/render": "^1.1.2",
+    "@stripe/react-stripe-js": "^3.9.0",
     "@stripe/stripe-js": "^7.8.0",
     "@supabase/ssr": "^0.6.1",
     "@upstash/ratelimit": "^2.0.5",

--- a/writerrank/src/components/DonationWidget.tsx
+++ b/writerrank/src/components/DonationWidget.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import React, { useState } from 'react';
+import { loadStripe } from '@stripe/stripe-js';
+import { Elements, CardElement, useStripe, useElements } from '@stripe/react-stripe-js';
+
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
+
+export default function DonationWidget() {
+  return (
+    <Elements stripe={stripePromise}>
+      <DonationForm />
+    </Elements>
+  );
+}
+
+const presetAmounts = [3, 5, 10];
+
+function DonationForm() {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [amount, setAmount] = useState<number | null>(presetAmounts[0]);
+  const [customAmount, setCustomAmount] = useState('');
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('');
+
+  const selectAmount = (amt: number) => {
+    setAmount(amt);
+    setCustomAmount('');
+  };
+
+  const handleCustomChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCustomAmount(e.target.value);
+    setAmount(null);
+  };
+
+  const getAmount = () => {
+    if (amount !== null) return amount;
+    const parsed = parseFloat(customAmount);
+    return isNaN(parsed) ? 0 : parsed;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError('');
+    setSuccess('');
+
+    if (!stripe || !elements) {
+      setError('Stripe has not loaded yet.');
+      setIsLoading(false);
+      return;
+    }
+
+    const chosenAmount = getAmount();
+    if (chosenAmount <= 0) {
+      setError('Please select a valid amount.');
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const response = await fetch('/api/create-payment-intent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          amount: Math.round(chosenAmount * 100),
+          donorEmail: email || undefined,
+        }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Payment initialization failed');
+
+      const cardElement = elements.getElement(CardElement);
+      if (!cardElement) throw new Error('Card element not found');
+
+      const paymentResult = await stripe.confirmCardPayment(data.clientSecret, {
+        payment_method: {
+          card: cardElement,
+          billing_details: { email: email || undefined },
+        },
+      });
+
+      if (paymentResult.error) throw new Error(paymentResult.error.message);
+
+      if (paymentResult.paymentIntent?.status === 'succeeded') {
+        setSuccess('Thank you for your donation!');
+        setEmail('');
+        setAmount(presetAmounts[0]);
+        setCustomAmount('');
+        cardElement.clear();
+      } else {
+        throw new Error('Payment was not successful.');
+      }
+    } catch (err: any) {
+      console.error(err);
+      setError(err.message || 'Payment failed.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="w-full max-w-md mx-auto p-6 bg-white rounded-lg shadow-md space-y-4">
+      <h3 className="text-xl font-semibold text-[color:var(--ow-neutral-900)] text-center">Support WriterRank</h3>
+
+      <div className="flex flex-wrap gap-2 justify-center">
+        {presetAmounts.map((amt) => (
+          <button
+            key={amt}
+            type="button"
+            onClick={() => selectAmount(amt)}
+            className={`px-4 py-2 rounded-md border transition-colors flex-1 sm:flex-none ${
+              amount === amt
+                ? 'bg-[color:var(--ow-orange-500)] text-white border-transparent'
+                : 'bg-white text-[color:var(--ow-neutral-900)] border-gray-300'
+            }`}
+          >
+            ${amt}
+          </button>
+        ))}
+        <input
+          type="number"
+          min="1"
+          placeholder="Custom"
+          value={customAmount}
+          onChange={handleCustomChange}
+          className="w-24 px-3 py-2 border border-gray-300 rounded-md"
+        />
+      </div>
+
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email (optional)"
+        className="w-full px-3 py-2 border border-gray-300 rounded-md"
+      />
+
+      <div className="p-3 border border-gray-300 rounded-md bg-white">
+        <CardElement
+          options={{
+            style: {
+              base: {
+                fontSize: '16px',
+                color: '#111827',
+                '::placeholder': { color: '#9CA3AF' },
+              },
+            },
+          }}
+        />
+      </div>
+
+      {error && <p className="text-sm text-red-600 text-center">{error}</p>}
+      {success && <p className="text-sm text-green-600 text-center">{success}</p>}
+
+      <button
+        type="submit"
+        disabled={isLoading}
+        className="w-full py-2 px-4 bg-[color:var(--ow-orange-500)] text-white font-semibold rounded-md hover:bg-[color:var(--ow-orange-500)]/90 disabled:opacity-50"
+      >
+        {isLoading ? 'Processing...' : 'Donate'}
+      </button>
+    </form>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Stripe-powered DonationWidget with preset amounts, custom input, email field, and success/error states
- install `@stripe/react-stripe-js`

## Testing
- `npm test` *(fails: Test timeout of 30000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_6891e0140c4c8332be47133aeb831033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a donation widget that allows users to make donations using Stripe, with options for preset or custom amounts and email receipts.
* **Chores**
  * Added Stripe integration dependency to support secure payment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->