### PR TITLE
feat: add about page route

### DIFF
--- a/writerrank/src/app/about/page.tsx
+++ b/writerrank/src/app/about/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import AboutContent from '@/components/AboutContent';
+
+export const metadata: Metadata = {
+  title: "About OpenWrite - Daily Writing Challenge Platform",
+  description: "Learn about OpenWrite's mission to make daily writing practice accessible to everyone. Discover our roadmap and support independent software.",
+};
+
+export default function AboutPage() {
+  return (
+    <main className="min-h-screen bg-ow-orange-50">
+      <div className="max-w-4xl mx-auto px-6 py-12">
+        <AboutContent />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add /about route that renders `AboutContent` with site-wide styling
- include SEO metadata for the about page

## Testing
- `npm test` *(fails: ENETUNREACH while patching lockfile, Playwright missing dependencies)*
- `npx eslint .` *(fails: 380 problems including no-unused-vars and framework rules)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e580f4748332b830f798a4299994