### PR TITLE
feat: update header navigation to about

### DIFF
--- a/writerrank/src/app/layout.tsx
+++ b/writerrank/src/app/layout.tsx
@@ -37,8 +37,8 @@ export default function RootLayout({
                 <h1 className="text-2xl font-bold text-[color:var(--ow-neutral-900)]">OpenWrite</h1>
               </a>
               <div className="flex items-center gap-3">
-                <a href="/donate" className="text-sm text-[color:var(--ow-neutral-900)] hover:underline">
-                  Support
+                <a href="/about" className="text-sm text-[color:var(--ow-neutral-900)] hover:underline">
+                  About
                 </a>
                 <SignedOut>
                   <SignInButton mode="modal">


### PR DESCRIPTION
## Summary
- replace Support link with About in header navigation

## Testing
- `npm test` *(fails: locator.click timeout; missing Start button)*
- `npx eslint .` *(fails: 2447 errors - large eslint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e96002808332bdb7419f276004cf